### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/phblock.php
+++ b/syntax/phblock.php
@@ -51,7 +51,7 @@ class syntax_plugin_phosphor_phblock extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	
         switch ($state) {
             case DOKU_LEXER_ENTER:
@@ -90,7 +90,7 @@ class syntax_plugin_phosphor_phblock extends DokuWiki_Syntax_Plugin {
 	/**
 	* Create output
 	*/
-    function render($mode, &$renderer, $input) {
+    function render($mode, Doku_Renderer $renderer, $input) {
 		global $conf;
         if($mode == 'xhtml'){
 

--- a/syntax/phitem.php
+++ b/syntax/phitem.php
@@ -51,7 +51,7 @@ class syntax_plugin_phosphor_phitem extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
     	
         switch ($state) {
             case DOKU_LEXER_ENTER:
@@ -85,7 +85,7 @@ class syntax_plugin_phosphor_phitem extends DokuWiki_Syntax_Plugin {
 	/**
 	* Create output
 	*/
-    function render($mode, &$renderer, $input) {
+    function render($mode, Doku_Renderer $renderer, $input) {
 		global $conf;
         if($mode == 'xhtml'){
 

--- a/syntax/phosphor.php
+++ b/syntax/phosphor.php
@@ -38,7 +38,7 @@ class syntax_plugin_phosphor_phosphor extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{phosphor>[^}]+}}', $mode, 'plugin_phosphor_phosphor');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $orig = substr($match, 11, -2);
         list($id, $background, $title) = explode('|', $orig, 3); // find ID/Params + Name Extension
@@ -55,7 +55,7 @@ class syntax_plugin_phosphor_phosphor extends DokuWiki_Syntax_Plugin {
         return array(trim($id), $title, $params, $orig);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
         if ($mode == 'xhtml') {
 			$this->phosphorContent($renderer, $data);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
